### PR TITLE
fix: add better handling of line breaks

### DIFF
--- a/styles.scss
+++ b/styles.scss
@@ -4,7 +4,7 @@
     font-weight: bold;
     position: relative;
     z-index: 1;
-    display: inline-block;
+    display: inline-flex;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     &.rainbow {


### PR DESCRIPTION
Changed the display option to inline-flex, as inline-block caused the background-clip:text to clip away too much on line breaks. At least when a max-width was set on its container.