### PR TITLE
Web Component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea
 css
+js
 node_modules
 package-lock.json

--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,6 @@
 .idea
 package-lock.json
 node_modules
-css
+gulpfile.js
+src
+index.html

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,13 @@
+const replace = require("gulp-replace");
+const { src, dest } = require("gulp");
+const fs = require("fs");
+
+function buildComponent() {
+  const styles = fs.readFileSync("./css/styles.css");
+
+  return src(["src/wordart.js"])
+    .pipe(replace("<style></style>", `<style>${styles}</style>`))
+    .pipe(dest("js/"));
+}
+
+exports.buildComponent = buildComponent;

--- a/index.html
+++ b/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <script src="/js/wordart.js"></script>
+  </head>
+  <body>
+    <p>This is text and this is <word-art theme="rainbow">WordArt</word-art>.</p>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
   "main": "index.js",
   "scripts": {
     "test": ":",
-    "build": "node-sass styles.scss -o css",
+    "build": "npm run build:css && npm run build:component",
+    "build:css": "node-sass styles.scss -o css",
+    "build:component": "gulp buildComponent",
     "postinstall": "npm run build"
   },
   "author": {
@@ -16,5 +18,9 @@
   "license": "MIT",
   "dependencies": {
     "node-sass": "^7.0.0"
+  },
+  "devDependencies": {
+    "gulp": "^4.0.2",
+    "gulp-replace": "^1.1.3"
   }
 }

--- a/src/wordart.js
+++ b/src/wordart.js
@@ -1,0 +1,26 @@
+const template = document.createElement("template");
+template.innerHTML = `
+<style></style>
+
+<div class="wordart">
+  <span class="text">
+      <slot></slot>
+  </span>
+</div>`;
+
+class WordArt extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: "open" });
+    this.shadowRoot.appendChild(template.content.cloneNode(true));
+  }
+
+  static get observedAttributes() {
+    return ["theme"];
+  }
+
+  attributeChangedCallback(name, oldValue, newValue) {
+    this.shadowRoot.querySelector(".wordart").className = "wordart " + newValue;
+  }
+}
+window.customElements.define("word-art", WordArt);


### PR DESCRIPTION
## PR content
 - web component definition so that people could use your amazing css wordart as one tag `<word-art/>`
 - include the js and css in the npm package so that people could use CDN like jsdelivr to use the package
 - gulpfile to take the component definition and fill it with the current CSS style
 - index.html to test the web component

## Motivation
My original motivation was to use the package in Angular so I have created an Angular binging (https://github.com/SmallhillCZ/angular-wordart) but then I realized why have React, Vue and Angular bindings, when you can use a simple Web Component which is cross compatible and can be simply used in any framework and also CMS.

## Usage
Locally:
```html
<script src="./css-wordart/js/wordart.js"></script>

<word-art theme="rainbow">WordArt Text</word-art>
```
JSDelivr CDN:
```html
<script src="https://cdn.jsdelivr.net/npm/css-wordart/js/wordart.js"></script>

<word-art theme="rainbow">WordArt Text</word-art>
```
