### PR TITLE
Migrate from node-sass -> sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "main": "index.js",
   "scripts": {
     "test": ":",
-    "build": "node-sass styles.scss -o css",
+    "build": "sass styles.scss css/styles.css",
     "postinstall": "npm run build"
   },
   "author": {
@@ -15,6 +15,6 @@
   },
   "license": "MIT",
   "dependencies": {
-    "node-sass": "^7.0.0"
+    "sass": "^1.85.1"
   }
 }


### PR DESCRIPTION
Hi Shalom - great repo, thanks for all the effort! (that level of CSS mastery is totally mind-boggling to me).

Anyway, I wanted to use your react-wordart package in a project but it wouldn't build on my Mac because of the node-sass dependency in css-wordart, so I just swapped node-sass (deprecated) with sass and updated the build script in package.json

Thanks!